### PR TITLE
Fixed errors for UE 4.24.3

### DIFF
--- a/GameLiftClientSDK/Source/AWSCore/AWSCore.Build.cs
+++ b/GameLiftClientSDK/Source/AWSCore/AWSCore.Build.cs
@@ -13,7 +13,7 @@ public class AWSCore : ModuleRules
 		PrivateDependencyModuleNames.AddRange(new string[] { });
 
         // This is required to fix a warning for Unreal Engine 4.21 and later
-        PrivatePCHHeaderFile = "Private/AWSCorePrivatePCH.h";
+        PrivatePCHHeaderFile = "Private/AWSCoreModulePrivatePCH.h";
 		
 		string BaseDirectory = System.IO.Path.GetFullPath(System.IO.Path.Combine(ModuleDirectory, "..", ".."));
         string ThirdPartyPath = System.IO.Path.Combine(BaseDirectory, "ThirdParty", "GameLiftClientSDK", Target.Platform.ToString());

--- a/GameLiftClientSDK/Source/AWSCore/Private/AWSCoreModule.cpp
+++ b/GameLiftClientSDK/Source/AWSCore/Private/AWSCoreModule.cpp
@@ -1,7 +1,7 @@
-#include "AWSCoreModulePrivatePCH.h"
 #include "AWSCoreModule.h"
+#include "AWSCoreModulePrivatePCH.h"
 #include "GameLiftClientSDK/Public/GameLiftClientGlobals.h"
-#include "IPluginManager.h"
+#include "Interfaces/IPluginManager.h"
 
 #define LOCTEXT_NAMESPACE "FAWSCoreModule"
 

--- a/GameLiftClientSDK/Source/AWSCore/Public/AWSCoreModule.h
+++ b/GameLiftClientSDK/Source/AWSCore/Public/AWSCoreModule.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ModuleManager.h"
+#include "Modules/ModuleManager.h"
 
 #include "aws/core/Aws.h"
 #include "aws/core/auth/AWSCredentialsProvider.h"

--- a/GameLiftClientSDK/Source/CognitoIdentity/CognitoIdentity.Build.cs
+++ b/GameLiftClientSDK/Source/CognitoIdentity/CognitoIdentity.Build.cs
@@ -11,7 +11,7 @@ public class CognitoIdentity : ModuleRules
 		PublicDependencyModuleNames.AddRange(new string[] { "Engine", "Core", "CoreUObject", "InputCore", "Projects" });
 		
 		// This is required to fix a warning for Unreal Engine 4.21 and later
-        PrivatePCHHeaderFile = "Private/CognitoIdentityPrivatePCH.h";
+        PrivatePCHHeaderFile = "Private/CognitoIdentityModulePrivatePCH.h";
 
 		string BaseDirectory = System.IO.Path.GetFullPath(System.IO.Path.Combine(ModuleDirectory, "..", ".."));
         string ThirdPartyPath = System.IO.Path.Combine(BaseDirectory, "ThirdParty", "GameLiftClientSDK", Target.Platform.ToString());

--- a/GameLiftClientSDK/Source/CognitoIdentity/Private/CognitoIdentityModule.cpp
+++ b/GameLiftClientSDK/Source/CognitoIdentity/Private/CognitoIdentityModule.cpp
@@ -1,7 +1,7 @@
-#include "CognitoIdentityModulePrivatePCH.h"
 #include "CognitoIdentityModule.h"
+#include "CognitoIdentityModulePrivatePCH.h"
 #include "GameLiftClientSDK/Public/GameLiftClientGlobals.h"
-#include "IPluginManager.h"
+#include "Interfaces/IPluginManager.h"
 
 #define LOCTEXT_NAMESPACE "FCognitoIdentityModule"
 

--- a/GameLiftClientSDK/Source/CognitoIdentity/Public/CognitoIdentityModule.h
+++ b/GameLiftClientSDK/Source/CognitoIdentity/Public/CognitoIdentityModule.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ModuleManager.h"
+#include "Modules/ModuleManager.h"
 
 class FCognitoIdentityModule : public IModuleInterface
 {

--- a/GameLiftClientSDK/Source/GameLiftClientSDK/Private/GameLiftClientSDK.cpp
+++ b/GameLiftClientSDK/Source/GameLiftClientSDK/Private/GameLiftClientSDK.cpp
@@ -3,8 +3,8 @@
 #include "GameLiftClientSDK.h"
 #include "GameLiftClientGlobals.h"
 #include "Core.h"
-#include "ModuleManager.h"
-#include "IPluginManager.h"
+#include "Modules/ModuleManager.h"
+#include "Interfaces/IPluginManager.h"
 
 #define LOCTEXT_NAMESPACE "FGameLiftClientSDKModule"
 

--- a/GameLiftClientSDK/Source/GameLiftClientSDK/Public/GameLiftClientSDK.h
+++ b/GameLiftClientSDK/Source/GameLiftClientSDK/Public/GameLiftClientSDK.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "ModuleManager.h"
+#include "Modules/ModuleManager.h"
 
 class FGameLiftClientSDKModule : public IModuleInterface
 {


### PR DESCRIPTION
I have updated the GameLiftClientSDK plugin to UE 4.24 GitHub version. It should also work with the Epic Games Launcher's version.